### PR TITLE
Disables keyboard shortcuts when an input in the members editor has focus - Fixes #5.

### DIFF
--- a/app/elements/slv-input.html
+++ b/app/elements/slv-input.html
@@ -78,10 +78,11 @@ Custom input element which gets a highlight when the field is focused.
           val: {
             value: '',
             reflect: true
+          },
+          hasFocus: {
+            value: false
           }
         },
-
-        hasFocus: false,
 
         lastValue: null,
 

--- a/app/elements/slv-members-editor.html
+++ b/app/elements/slv-members-editor.html
@@ -170,6 +170,7 @@ listeners when the values are edited.
 
       <div class="field">
         <slv-input id="nodeLabel" val="{{ nodeLabel }}"
+                    hasFocus="{{ needFocus }}"
                     on-blur="{{ save }}">
         </slv-input>
       </div>
@@ -192,6 +193,7 @@ listeners when the values are edited.
           <div class="field no-label">
             <slv-input id="member-{{ member.name }}"
                         data-member="{{ member.name }}"
+                        hasFocus="{{ needFocus }}"
                         on-blur="{{ save }}"
                         val="{{ member.value }}">
             </slv-input>
@@ -220,6 +222,7 @@ listeners when the values are edited.
               <slv-input id="member-{{ member.name }}-val"
                           class="field small-field"
                           data-member-part="val"
+                          hasFocus="{{ needFocus }}"
                           on-blur="{{ save }}"
                           val="{{ member.value.val }}">
               </slv-input>
@@ -232,6 +235,7 @@ listeners when the values are edited.
               <slv-input id="member-{{ member.name }}-step"
                           class="field small-field"
                           data-member-part="step"
+                          hasFocus="{{ needFocus }}"
                           on-blur="{{ save }}"
                           val="{{ member.value.step }}">
               </slv-input>
@@ -244,6 +248,7 @@ listeners when the values are edited.
               <slv-input id="member-{{ member.name }}-max"
                           class="field small-field"
                           data-member-part="max"
+                          hasFocus="{{ needFocus }}"
                           on-blur="{{ save }}"
                           val="{{ member.value.max }}">
               </slv-input>
@@ -256,6 +261,7 @@ listeners when the values are edited.
               <slv-input id="member-{{ member.name }}-min"
                           class="field small-field"
                           data-member-part="min"
+                          hasFocus="{{ needFocus }}"
                           on-blur="{{ save }}"
                           val="{{ member.value.min }}">
               </slv-input>
@@ -421,6 +427,8 @@ listeners when the values are edited.
 
         created: function () {
           this.signals = {
+            needKeyboardFocus: new signals.Signal(),
+
             // dispatched with nodeId, nodeLabel, name/value pairs for member
             // variables in the node
             membersUpdated: new signals.Signal()
@@ -507,6 +515,12 @@ listeners when the values are edited.
           }, []);
 
           return members;
+        },
+
+        needFocus: false,
+
+        needFocusChanged: function (oldValue, newValue) {
+          this.signals.needKeyboardFocus.dispatch(newValue);
         },
 
         /**

--- a/app/js/KeyboardShortcuts.js
+++ b/app/js/KeyboardShortcuts.js
@@ -48,6 +48,15 @@ define(['lodash', 'js-signals'], function (_, jssignals) {
     'keyboardInput': new jssignals.Signal()
   };
 
+  var enable = function () {
+    _installKeyboardShortcuts();
+  };
+
+  var disable = function () {
+    Mousetrap.reset();
+    _installed = false;
+  };
+
   var setGraph = function (newGraph) {
     graph = newGraph;
     selectedNodes = [];
@@ -141,6 +150,8 @@ define(['lodash', 'js-signals'], function (_, jssignals) {
   };
 
   return {
+    disable: disable,
+    enable: enable,
     setGraph: setGraph,
     setEditor: setEditor,
     setSelectedEdges: setSelectedEdges,

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -92,6 +92,15 @@ Promise.all([
     versionedGraphBuilder.setMetadata(nodeId, nodeLabel, members);
   });
 
+  // enable/disable keyboad shortcuts when membersEditor needs focus for text input
+  membersEditor.signals.needKeyboardFocus.add(function (needFocus) {
+    if (needFocus) {
+      KeyboardShortcuts.disable();
+    } else {
+      KeyboardShortcuts.enable();
+    }
+  });
+
   // change the component associated with a node
   editor.signals.componentSelected.add(function (nodeId, componentName) {
     var component = editor.getLibrary().get(componentName);


### PR DESCRIPTION
Fixes #5

To test, create a node, select it, focus the name field, use left/right arrow keys to move cursor. Click outside the name field, and use left/right keys to move selected node (assuming it is still selected - nothing happens otherwise).
